### PR TITLE
Update async_ usage (for Home Assistant 0.66+)

### DIFF
--- a/zigate/__init__.py
+++ b/zigate/__init__.py
@@ -4,7 +4,14 @@ Support for ZiGate
 
 import asyncio
 import logging
-from homeassistant.util import async as hasync
+try:
+    # Valid since HomeAssistant 0.66+
+    from homeassistant.util import async_ as hasync
+except ImportError:
+    # backwards compatibility, with workaround to avoid reserved word "async"
+    # from homeassistant.util import async as hasync  # <- invalid syntax in Python 3.7
+    import importlib
+    hasync = importlib.import_module("homeassistant.util.async")
 
 import homeassistant.helpers.config_validation as cv
 from homeassistant.const import (CONF_NAME, CONF_HOST, CONF_PORT)


### PR DESCRIPTION
This should workd for Home Assistant 0.66+ onwards, but keeping backwards compatibility.

Note that there is an extra workaround to avoid `async` completely, as it will give syntax error under Python 3.7. This should future-proof the import.

Solves #17 