### PR TITLE
Add restore_state support for sensors

### DIFF
--- a/sensor/zigate.py
+++ b/sensor/zigate.py
@@ -4,13 +4,18 @@ ZiGate platform for Zigbee sensors.
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 from homeassistant.helpers.dispatcher import (dispatcher_connect, dispatcher_send)
+from homeassistant.helpers.restore_state import async_get_last_state
 from homeassistant.const import (CONF_NAME, CONF_ADDRESS, STATE_UNKNOWN)
 import homeassistant.helpers.config_validation as cv
 
+import asyncio
+import logging
 import voluptuous as vol
 
 from custom_components.zigate.const import *
 from pyzigate.zgt_parameters import *
+
+_LOGGER = logging.getLogger(__name__)
 
 CONF_DEFAULT_ATTR = 'default_state'
 CONF_DEFAULT_UNIT = 'default_unit'
@@ -72,3 +77,10 @@ class ZiGateSensor(Entity):
         self.schedule_update_ha_state()
 
 
+    @asyncio.coroutine
+    def async_added_to_hass(self):
+        """Handle entity which will be added."""
+        state = yield from async_get_last_state(self.hass, self.entity_id)
+        if state:
+            self._attributes.update(state.attributes)
+            _LOGGER.info('{}: got attributes from last state: {}'.format(self._name, self._attributes))

--- a/sensor/zigate.py
+++ b/sensor/zigate.py
@@ -82,5 +82,7 @@ class ZiGateSensor(Entity):
         """Handle entity which will be added."""
         state = yield from async_get_last_state(self.hass, self.entity_id)
         if state:
-            self._attributes.update(state.attributes)
-            _LOGGER.info('{}: got attributes from last state: {}'.format(self._name, self._attributes))
+            for attr in iter(state.attributes):
+                if (attr != 'friendly_name' and attr != 'last seen'):
+                    _LOGGER.info('{}: set attribute {} from last state: {}'.format(self._name, attr, state.attributes[attr]))
+                    self.update_attributes(attr, state.attributes[attr])

--- a/sensor/zigate.py
+++ b/sensor/zigate.py
@@ -5,7 +5,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 from homeassistant.helpers.dispatcher import (dispatcher_connect, dispatcher_send)
 from homeassistant.helpers.restore_state import async_get_last_state
-from homeassistant.const import (CONF_NAME, CONF_ADDRESS, STATE_UNKNOWN)
+from homeassistant.const import (CONF_NAME, CONF_ADDRESS, STATE_UNKNOWN, ATTR_FRIENDLY_NAME)
 import homeassistant.helpers.config_validation as cv
 
 import asyncio
@@ -83,6 +83,6 @@ class ZiGateSensor(Entity):
         state = yield from async_get_last_state(self.hass, self.entity_id)
         if state:
             for attr in iter(state.attributes):
-                if (attr != 'friendly_name' and attr != 'last seen'):
+                if attr != ATTR_FRIENDLY_NAME:
                     _LOGGER.info('{}: set attribute {} from last state: {}'.format(self._name, attr, state.attributes[attr]))
                     self.update_attributes(attr, state.attributes[attr])


### PR DESCRIPTION
A lot of sensors (i.e. the Xiaomi temperature sensors) send state
updates only if the data has changed. There is no way to poll the
current state. Thus, after a restart of home assistant, it can take
hours or even days until a value is available.

Use the restore_state (together with the recorder component) to set
the state initially to the last known value.